### PR TITLE
Removing all references to block nonces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ typings/
 
 dump.rdb
 peerId.json
+
+.DS_Store
+.vscode
+

--- a/backend/migrations/sqls/20190508172744-create-schema-up.sql
+++ b/backend/migrations/sqls/20190508172744-create-schema-up.sql
@@ -59,7 +59,6 @@ CREATE TABLE blocks (
   height bigint NOT NULL,
   miner character varying(41) NOT NULL,
   parent_weight bigint NOT NULL,
-  nonce bigint NOT NULL,
   ingested_at bigint NOT NULL,
   parent_tipset_hashes character varying[],
   tipset_hash character varying NOT NULL

--- a/backend/src/client/ChainClient.ts
+++ b/backend/src/client/ChainClient.ts
@@ -115,7 +115,6 @@ export class ChainClientImpl implements IChainClient {
       parents,
       miner: json.Header.miner,
       parentWeight: Number(json.Header.parentWeight),
-      nonce: Number(json.Header.nonce),
       messages: this.inflateMessages(json.Messages, height, tipsetHash),
     };
   }

--- a/backend/src/domain/Block.ts
+++ b/backend/src/domain/Block.ts
@@ -2,7 +2,6 @@ export interface Block {
   height: number
   miner: string
   parentWeight: number
-  nonce: number
   ingestedAt: number
   parents: string[]
 }

--- a/backend/src/domain/BlockFromClient.ts
+++ b/backend/src/domain/BlockFromClient.ts
@@ -11,7 +11,6 @@ export interface BlockFromClient {
 
   parentWeight: number
 
-  nonce: number
 }
 
 export type BlockFromClientWithMessages = BlockFromClient & {

--- a/backend/src/domain/BlockJSON.ts
+++ b/backend/src/domain/BlockJSON.ts
@@ -11,15 +11,13 @@ export interface RawBlockJSON {
 export interface RawHeader {
   miner: string;
 
-  ticket: string;
+  tickets: any[];
 
   parents: { '/': string }[];
 
   parentWeight: string;
 
   height: string;
-
-  nonce: string;
     
   stateRoot: { [k: string]: string };
 

--- a/backend/src/service/dao/BlocksDAO.ts
+++ b/backend/src/service/dao/BlocksDAO.ts
@@ -119,7 +119,6 @@ export class PostgresBlocksDAO implements IBlocksDAO {
       height: row.height,
       miner: row.miner,
       parentWeight: row.parent_weight,
-      nonce: row.nonce,
       ingestedAt: row.ingested_at,
       parents: row.parent_tipset_hashes,
     };

--- a/backend/src/service/dao/ChainsawDAO.ts
+++ b/backend/src/service/dao/ChainsawDAO.ts
@@ -4,6 +4,7 @@ import {ITimestampProvider} from '../TimestampProvider';
 import {BlockFromClientWithMessages} from '../../domain/BlockFromClient';
 import {MinerUpdate} from '../../domain/MinerUpdate';
 import {IBlocksDAO} from './BlocksDAO';
+import { loggers } from 'winston';
 
 export interface IChainsawDAO {
   lastBlock (): Promise<number>
@@ -48,12 +49,11 @@ export default class PostgresChainsawDAO implements IChainsawDAO {
         }
 
         await client.query(
-          'INSERT INTO blocks(height, miner, parent_weight, nonce, ingested_at, parent_tipset_hashes, tipset_hash) VALUES ($1, $2, $3, $4, $5, $6, $7)',
+          'INSERT INTO blocks(height, miner, parent_weight, ingested_at, parent_tipset_hashes, tipset_hash) VALUES ($1, $2, $3, $4, $5, $6)',
           [
             block.height,
             block.miner,
             block.parentWeight,
-            block.nonce,
             this.tsp.now(),
             block.parents,
             block.tipsetHash,


### PR DESCRIPTION
- Block nonces are removed in https://github.com/filecoin-project/go-filecoin/issues/3248 (message nonces are still used)
- Also changing tickets to an array in BlockJSON.ts, although tickets don't seem to be used anywhere and is not in the database

