### PR TITLE
change network label in header based on devnet type

### DIFF
--- a/frontend/src/components/GlobalNav.scss
+++ b/frontend/src/components/GlobalNav.scss
@@ -48,7 +48,6 @@
       font-size: .9em;
       display: flex;
       flex-direction: column;
-      display: none; /* hiding for now for staging dashboard */ 
       &:not(:first-child) {
         margin-left: $base * 2;
       }

--- a/frontend/src/components/GlobalNav.tsx
+++ b/frontend/src/components/GlobalNav.tsx
@@ -36,6 +36,19 @@ const HeaderStateProps = class GlobalNav extends React.Component<HeaderStateProp
   renderGlobalNav () {
     const style= this.props.isShowingGlobalNav ? {} : { display: 'none'};
 
+    var location = window.location.href;
+    
+    var network_type = 'user'; // default is user devnet
+
+    var re_staging = /staging/gi;
+    var re_local = /local/gi;
+
+    if (location.search(re_staging) !== -1 ) { 
+      network_type = 'staging';
+    } else if (location.search(re_local) !== -1 ) { 
+      network_type = 'local';
+    }
+
     return (
       <div className={c(b(), b(null, 'full-size'))} style={style}>
         <div className={b(null, 'inner')}>
@@ -43,18 +56,8 @@ const HeaderStateProps = class GlobalNav extends React.Component<HeaderStateProp
             <img src="/assets/logo-nopadding.svg" alt="FileCoin" />
             Filecoin
           </Link>
-          {this.renderNetworkInfo()}
-          <div className={b(null, 'links')}>
-            <BaseDropdown title='Links'>
-              <ul>
-                <li><a href="http://user.kittyhawk.wtf:8000/" target="_blank">Block Explorer</a></li>
-                <li><a href="http://user.kittyhawk.wtf:9797/" target="_blank">Faucet</a></li>
-                <li><a href="https://github.com/filecoin-project/go-filecoin/wiki/Troubleshooting-&-FAQ#known-issues" target="_blank">Known Issues</a></li>
-                <li><a href="https://discuss.filecoin.io/" target="_blank">Forums</a></li>
-                <li><a href="https://filecoin.io/faqs/" target="_blank">FAQs</a></li>
-              </ul>
-            </BaseDropdown>
-          </div>
+          {this.renderNetworkInfo(network_type)}
+          {this.renderNetworkLinks(network_type)}
         </div>
       </div>
     );
@@ -74,27 +77,77 @@ const HeaderStateProps = class GlobalNav extends React.Component<HeaderStateProp
     }
   }
 
-  renderNetworkRelease () {
-    const style = this.props.currentNetwork == Network.STABLE ? {} : { display: 'none'};
+  checkNetworkType () {
+    var location = window.location.href;
+    var re_staging = /staging/gi;
+    var re_local = /local/gi;
+    var network_type = 'user'; // default is user devnet
+
+    if (location.search(re_staging) !== -1 ) { 
+      network_type = 'staging';
+    } else if (location.search(re_local) !== -1 ) { 
+      network_type = 'local';
+    }
+    return network_type;
+  }
+
+  renderNetworkLinks = (network_type : string) => {
+
+    // default is user devnet links
+    var explorer_url = 'http://user.kittyhawk.wtf:8000/';
+    var faucet_url = 'http://user.kittyhawk.wtf:9797/';
+
+    if (network_type === 'staging') {
+      explorer_url = 'https://explorer.staging.kittyhawk.wtf/';
+      faucet_url = 'https://faucet.staging.kittyhawk.wtf/';
+    }
 
     return (
-      <div className={b(null, 'info')} style={style}>
+      <div className={b(null, 'links')}>
+        <BaseDropdown title='Links'>
+          <ul>
+            <li><a href={explorer_url} target="_blank">Block Explorer</a></li>
+            <li><a href={faucet_url} target="_blank">Faucet</a></li>
+            <li><a href="https://github.com/filecoin-project/go-filecoin/wiki/Troubleshooting-&-FAQ#known-issues" target="_blank">Known Issues</a></li>
+            <li><a href="https://discuss.filecoin.io/" target="_blank">Forums</a></li>
+            <li><a href="https://filecoin.io/faqs/" target="_blank">FAQs</a></li>
+          </ul>
+        </BaseDropdown>
+      </div>
+    )
+  };
+
+  renderNetworkRelease = (network_type: string) => {
+    var src_url = "https://img.shields.io/endpoint.svg?color=3FC1CB&labelColor=3FC1CB&style=flat-square&label=User%20Devnet&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/user-devnet.json"; // default is user devnet
+
+    if (network_type === 'staging') {
+      src_url = "https://img.shields.io/endpoint.svg?color=3FC1CB&labelColor=3FC1CB&style=flat-square&label=Staging%20Devnet&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/staging-devnet.json"; 
+
+    } else if (network_type === 'local') {
+      src_url = "https://img.shields.io/badge/-Dashboard%20Localhost-brightgreen"; 
+    }
+
+    return (
+      <div className={b(null, 'info')}>
         <span className="label">Network</span>
         <span className="name">
           <a href="https://github.com/filecoin-project/go-filecoin/releases/latest" target="_blank">
-            <img src="https://img.shields.io/endpoint.svg?color=3FC1CB&labelColor=3FC1CB&style=flat-square&label=User%20Devnet&url=https://raw.githubusercontent.com/filecoin-project/go-filecoin-badges/master/user-devnet.json" />
+            <img src={src_url} />
           </a>
         </span>
       </div>
     )
-  }
+  };
 
-  renderNetworkInfo () {
-    const style = this.props.isShowingNetworks ? {} : { display: 'none'};
+  renderNetworkInfo (network_type : string) {
+    var style = this.props.isShowingNetworks ? {} : { display: 'none'};
+    if (network_type === '') {
+      style = { display: 'none'};
+    }
 
     return (
       <div className={b(null, 'info-group')} style={style}>
-        {this.renderNetworkRelease()}
+        {this.renderNetworkRelease(network_type)}
       </div>
     );
   }


### PR DESCRIPTION
Now that the staging devnet also hosts a stats dashboard, this checks the window's url for 'staging' and updates:

- the network name and version
- the faucet and explorer links in the Links dropdown
