### PR TITLE
decode to "0" instead of "NaN" from BigIntDecoder

### DIFF
--- a/backend/src/client/ABI.ts
+++ b/backend/src/client/ABI.ts
@@ -21,6 +21,10 @@ export const BytesAmountDecoder: TypeDecoder<string> = {
 
 export const BigIntDecoder: TypeDecoder<string> = {
   decode (buf: Buffer): string {
+    if (buf.length === 0) {
+      return '0'
+    }
+
     return new BigNumber(`0x${buf.toString('hex')}`).toFixed(0);
   },
 };


### PR DESCRIPTION
[`BigIntDecoder`](https://github.com/filecoin-project/filecoin-network-stats/blob/master/backend/src/client/ABI.ts#L22) returns `NaN` when an empty buffer is passed. This seems to be a pretty harmless patch to "unstuck" the deployed dashboard by returning `'0'` when an empty buffer is passed to the `BigIntDecoder`. More info in [this gist](https://gist.github.com/Schwartz10/3b93ff897e2a492c9281de80a7dfa628).

Will submit a proper fix once we have a better understanding of why the `addAsk` message comes back with an empty buffer param. 