### PR TITLE
chore(doc): add status to README in prep for archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # filecoin-network-stats
 
-(Deprecated) Dashboard built by Kyokan for tracking network state of the **go-filecoin** devnets in 2019.
+Dashboard built by Kyokan for tracking network state of the **go-filecoin** devnets in 2019.
 
-This project is no longer active.
+## Status
 
-It was used with an earlier go-filecoin node implementation pre-September 2019.
+This repository is in a **frozen** state. It is not being maintained or kept in sync with the libraries it depends on. This library was designed for an early version of _go-filecoin_, which is now known as [Venus](https://venus.filecoin.io/). An API client for Lotus can be found at https://github.com/filecoin-shipyard/js-lotus-client-rpc that may be used to build similar functionality. Even though this work on this repository has been **shelved**, anyone interested in updating or maintaining this library should express their interest on one Filecoin community conversation mediums: <https://github.com/filecoin-project/community#join-the-community>.
+
+---
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dashboard built by Kyokan for tracking network state of the **go-filecoin** devn
 
 ## Status
 
-This repository is in a **frozen** state. It is not being maintained or kept in sync with the libraries it depends on. This library was designed for an early version of _go-filecoin_, which is now known as [Venus](https://venus.filecoin.io/). An API client for Lotus can be found at https://github.com/filecoin-shipyard/js-lotus-client-rpc that may be used to build similar functionality. Even though this work on this repository has been **shelved**, anyone interested in updating or maintaining this library should express their interest on one Filecoin community conversation mediums: <https://github.com/filecoin-project/community#join-the-community>.
+This repository is in a **frozen** state. It is not being maintained or kept in sync with the libraries it depends on. This library was designed for an early version of _go-filecoin_, which is now known as [Venus](https://venus.filecoin.io/). An API client for Lotus can be found at https://github.com/filecoin-shipyard/js-lotus-client-rpc that may be used to build similar functionality. Even though work on this repository has been **shelved**, anyone interested in updating or maintaining this library should express their interest on one Filecoin community conversation mediums: <https://github.com/filecoin-project/community#join-the-community>.
 
 ---
 


### PR DESCRIPTION
Mainly just cleans up and clarifies the deprecation notice eshon already added and makes it consistent with the other status messages being added to repos in filecoin-shipyard.

Will archive the repo after merge.